### PR TITLE
Fix resolving page id when multiple digits

### DIFF
--- a/.azext/changelog-prod.json
+++ b/.azext/changelog-prod.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "1.0.4",
+    "publishDate": "2022-03-23",
+    "changes": [
+      {
+        "type": "fix",
+        "description": "Fixed an issue where the extension would fail to resolve the wiki url when the id of the page is greater than 9"
+      }
+    ]
+  },
+  {
     "version": "1.0.3",
     "publishDate": "2022-03-06",
     "changes": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.0.4 (2022-03-23)
+
+### 🐛 Fixes (1)
+
+- Fixed an issue where the extension would fail to resolve the wiki url when the id of the page is greater than 9
+
+---
+
 ## 1.0.3 (2022-03-06)
 
 ### 📝 Documentation (1)

--- a/src/common/parseWikiUrl.ts
+++ b/src/common/parseWikiUrl.ts
@@ -5,7 +5,7 @@ export interface IWikiPage {
 }
 
 export const parseWikiUrl = (url: string): IWikiPage | undefined => {
-  const expression = /_wiki\/wikis\/(?<wikiName>.+)\/(?<wikiId>\d)\/(?<wikiPath>.+)/gm;
+  const expression = /_wiki\/wikis\/(?<wikiName>.+)\/(?<wikiId>\d+)\/(?<wikiPath>.+)/gm;
   let m;
 
   while ((m = expression.exec(url)) !== null) {


### PR DESCRIPTION
Fixed an issue where the parsing logic would fail to resolve a url where the ID of the wiki page consisted of multiple digits.